### PR TITLE
Updated CHANGELOG.md for GitHub.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [1.2.0]
 
-### Added
+- Initial open source version of EmbeddedInfraLib
 
-- This CHANGELOG file to keep track of changes to this project
-- Initial support for compilation under Darwin (OSX)
-
-### Changed
-
-- Updated googletest to v1.8.1
-- Made CCola play nice with Visual Studio 2019 native CMake support
-
-## [1.1.0]
-
-- Initial export of EmbeddedInfraLib to Philips Open Source
-
-
-[Unreleased]: https://gitlab.ta.philips.com/open-source/embeddedinfralib/compare/v1.2.0...HEAD
-[1.2.0]: https://gitlab.ta.philips.com/open-source/embeddedinfralib/compare/v1.1.0...v1.2.0
-[1.1.0]: https://gitlab.ta.philips.com/open-source/embeddedinfralib/releases/tag/v1.1.0
+[Unreleased]: https://github.com/philps-software/embeddedinfralib/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/philps-software/embeddedinfralib/releases/tag/v1.2.0


### PR DESCRIPTION
Updated CHANGELOG.md for GitHub releases. After this commit we can create the v1.2.0 release and have our administration up-to-date.