### PR TITLE
Excludes generated source in language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+lwip/* linguist-vendored
+external/* linguist-vendored
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-- Ignore external vendor packages in language analyse on github
+### Added
+
+- Ignore external vendor packages in language analysis on github
 
 ## [1.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+- Ignore external vendor packages in language analyse on github
+
 ## [1.2.0]
 
 - Initial open source version of EmbeddedInfraLib


### PR DESCRIPTION
Removes the files of external libraries in source detection.

See difference:

[![asciicast](https://asciinema.org/a/2thhhvjtSY07AxK6nMcWHhONf.svg)](https://asciinema.org/a/2thhhvjtSY07AxK6nMcWHhONf)