### PR TITLE
fix for building using clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(TARGET_BUILD_WIN On)
     set(TARGET_ARCH_X86 On)
 
-    add_compile_options(/EHsc)
+    add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/EHsc>)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/hal/windows/UartWindows.hpp
+++ b/hal/windows/UartWindows.hpp
@@ -49,7 +49,7 @@ namespace hal
                 space = SPACEPARITY
             };
 
-            UartWindowsConfig(){}
+            UartWindowsConfig() {}
 
             UartWindowsConfig(uint32_t newbaudRate, RtsFlowControl newFlowControlRts)
                 : baudRate(newbaudRate)

--- a/hal/windows/UartWindows.hpp
+++ b/hal/windows/UartWindows.hpp
@@ -49,7 +49,7 @@ namespace hal
                 space = SPACEPARITY
             };
 
-            UartWindowsConfig() = default;
+            UartWindowsConfig(){}
 
             UartWindowsConfig(uint32_t newbaudRate, RtsFlowControl newFlowControlRts)
                 : baudRate(newbaudRate)


### PR DESCRIPTION
For more information w.r.t. to the default initialization issue in UartWindows.hpp, see: https://godbolt.org/z/E7qGE375K