### PR TITLE
Closes #54: std::result_of deprecation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,10 @@
   "mounts": [
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
   ],
-  "extensions": ["matepek.vscode-catch2-test-adapter", "ms-vscode.cmake-tools", "ms-vscode.cpptools", "twxs.cmake"]
+  "extensions": [
+    "matepek.vscode-catch2-test-adapter",
+    "ms-vscode.cmake-tools",
+    "ms-vscode.cpptools",
+    "twxs.cmake"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EmbeddedInfraLib (EmIL)
 
-[![Continuous Integration](https://github.com/philips-software/embeddedinfralib/workflows/Continuous%20Integration/badge.svg)](https://github.com/philips-software/embeddedinfralib/actions) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=philips-software_embeddedinfralib&metric=alert_status)](https://sonarcloud.io/dashboard?id=philips-software_embeddedinfralib) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=philips-software_embeddedinfralib&metric=coverage)](https://sonarcloud.io/dashboard?id=philips-software_embeddedinfralib) [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT) [![Documentation](https://img.shields.io/website?down_message=offline&label=Documentation&up_message=online&url=https%3A%2F%2Fimg.shields.io%2Fwebsite-up-down-green-red%2Fhttps%2Fphilips-software.github.io%2Fembeddedinfralib.svg)](https://philips-software.github.io/embeddedinfralib/)
+[![Continuous Integration](https://github.com/philips-software/embeddedinfralib/workflows/Continuous%20Integration/badge.svg)](https://github.com/philips-software/embeddedinfralib/actions) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=philips-software_embeddedinfralib&metric=alert_status)](https://sonarcloud.io/dashboard?id=philips-software_embeddedinfralib) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=philips-software_embeddedinfralib&metric=coverage)](https://sonarcloud.io/dashboard?id=philips-software_embeddedinfralib) [![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://choosealicense.com/licenses/mit/) [![Documentation](https://img.shields.io/website?down_message=offline&label=Documentation&up_message=online&url=https%3A%2F%2Fimg.shields.io%2Fwebsite-up-down-green-red%2Fhttps%2Fphilips-software.github.io%2Fembeddedinfralib.svg)](https://philips-software.github.io/embeddedinfralib/)
 
 **Description**: EmbeddedInfraLib is a set of C++ libraries and headers that provide heap-less, STL like, infrastructure for embedded software development.
 
@@ -46,4 +46,4 @@ Please refer to our [Contributing](CONTRIBUTING.md) guide when you want to contr
 
 ## License
 
-EmbeddedInfraLib is licenced under the [MIT](https://opensource.org/licenses/MIT) license. See [LICENSE file](LICENSE.md).
+EmbeddedInfraLib is licenced under the [MIT](https://choosealicense.com/licenses/mit/) license. See [LICENSE file](LICENSE.md).

--- a/infra/util/CMakeLists.txt
+++ b/infra/util/CMakeLists.txt
@@ -6,6 +6,12 @@ target_include_directories(infra.util PUBLIC
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
+target_compile_options(infra.util PUBLIC
+    $<$<CXX_COMPILER_ID:MSVC>:
+        /Zc:__cplusplus
+    >
+)
+
 target_sources(infra.util PRIVATE
     Aligned.hpp
     Allocator.hpp
@@ -23,6 +29,7 @@ target_sources(infra.util PRIVATE
     BoundedVector.hpp
     ByteRange.hpp
     CompareMembers.hpp
+    Compatibility.hpp
     ConstructBin.cpp
     ConstructBin.hpp
     CrcCcittCalculator.cpp

--- a/infra/util/Compatibility.hpp
+++ b/infra/util/Compatibility.hpp
@@ -1,0 +1,18 @@
+#ifndef INFRA_COMPATIBILITY_HPP
+#define INFRA_COMPATIBILITY_HPP
+
+#include <type_traits>
+
+namespace infra
+{
+    // Compatibility helper for deprecation of std::result_of in C++17
+    // See: https://en.cppreference.com/w/cpp/types/result_of
+    template<class A, class B>
+#if __cplusplus < 201703L
+    using result_of_t = typename std::result_of<A(B&)>::type;
+#else
+    using result_of_t = std::invoke_result_t<A, B&>;
+#endif
+}
+
+#endif

--- a/infra/util/Compatibility.hpp
+++ b/infra/util/Compatibility.hpp
@@ -3,15 +3,37 @@
 
 #include <type_traits>
 
+// This file contains compatibility wrappers for features that
+// are not present in all versions of the C++ standard.
+// It tries to provide a homogeneous way to use these features
+// in client-code; while maintaining compatibility across standards
+// from C++11 and higher.
+
 namespace infra
 {
+    static_assert(__cplusplus != 199711L, "The C++ standard selected is too old, or the /Zc:__cplusplus flag has not been set when using MSVC");
+
     // Compatibility helper for deprecation of std::result_of in C++17
     // See: https://en.cppreference.com/w/cpp/types/result_of
-    template<class A, class B>
+    template<class F, class... ArgTypes>
 #if __cplusplus < 201703L
-    using result_of_t = typename std::result_of<A(B&)>::type;
+    using result_of_t = typename std::result_of<F(ArgTypes...)>::type;
 #else
-    using result_of_t = std::invoke_result_t<A, B&>;
+    using result_of_t = std::invoke_result_t<F, ArgTypes...>;
+#endif
+
+    template<class T, class U>
+#if __cplusplus < 201703L
+    using is_same_v = typename std::is_same<T, U>::value;
+#else
+    inline constexpr bool is_same_v = std::is_same_v<T, U>;
+#endif
+
+    template<bool B, class T = void>
+#if __cplusplus < 201402L
+    using enable_if_t = typename enable_if<B, T>::type;
+#else
+    using enable_if_t = std::enable_if_t<B, T>;
 #endif
 }
 

--- a/infra/util/Compatibility.hpp
+++ b/infra/util/Compatibility.hpp
@@ -22,13 +22,6 @@ namespace infra
     using result_of_t = std::invoke_result_t<F, ArgTypes...>;
 #endif
 
-    template<class T, class U>
-#if __cplusplus < 201703L
-    using is_same_v = typename std::is_same<T, U>::value;
-#else
-    inline constexpr bool is_same_v = std::is_same_v<T, U>;
-#endif
-
     template<bool B, class T = void>
 #if __cplusplus < 201402L
     using enable_if_t = typename enable_if<B, T>::type;

--- a/infra/util/Observer.hpp
+++ b/infra/util/Observer.hpp
@@ -85,13 +85,13 @@ namespace infra
 
     public:
         template<class F>
-            void NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0) const;
+            void NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr) const;
         template<class F>
-            void NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0);
+            void NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr);
         template<class F>
-            bool NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0) const;
+            bool NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr) const;
         template<class F>
-            bool NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0);
+            bool NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr);
 
     private:
         IntrusiveList<Observer<ObserverType_, SubjectType>> observers;
@@ -215,7 +215,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    void Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
+    void Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::const_iterator i = observers.begin(); i != observers.end(); )
         {
@@ -227,7 +227,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    void Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
+    void Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::iterator i = observers.begin(); i != observers.end();)
         {
@@ -239,7 +239,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
+    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::const_iterator i = observers.begin(); i != observers.end(); )
         {
@@ -254,7 +254,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
+    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::iterator i = observers.begin(); i != observers.end();)
         {

--- a/infra/util/Observer.hpp
+++ b/infra/util/Observer.hpp
@@ -85,13 +85,13 @@ namespace infra
 
     public:
         template<class F>
-            void NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr) const;
+            void NotifyObservers(F callback, infra::enable_if_t<std::is_same<infra::result_of_t<F, ObserverType_&>, void>::value>* = nullptr) const;
         template<class F>
-            void NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr);
+            void NotifyObservers(F callback, infra::enable_if_t<std::is_same<infra::result_of_t<F, ObserverType_&>, void>::value>* = nullptr);
         template<class F>
-            bool NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr) const;
+            bool NotifyObservers(F callback, infra::enable_if_t<!std::is_same<infra::result_of_t<F, ObserverType_&>, void>::value>* = nullptr) const;
         template<class F>
-            bool NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = nullptr);
+            bool NotifyObservers(F callback, infra::enable_if_t<!std::is_same<infra::result_of_t<F, ObserverType_&>, void>::value>* = nullptr);
 
     private:
         IntrusiveList<Observer<ObserverType_, SubjectType>> observers;
@@ -215,7 +215,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    void Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
+    void Subject<ObserverType, void>::NotifyObservers(F callback, infra::enable_if_t<std::is_same<infra::result_of_t<F, ObserverType&>, void>::value>*) const
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::const_iterator i = observers.begin(); i != observers.end(); )
         {
@@ -227,7 +227,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    void Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
+    void Subject<ObserverType, void>::NotifyObservers(F callback, infra::enable_if_t<std::is_same<infra::result_of_t<F, ObserverType&>, void>::value>*)
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::iterator i = observers.begin(); i != observers.end();)
         {
@@ -239,7 +239,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
+    bool Subject<ObserverType, void>::NotifyObservers(F callback, infra::enable_if_t<!std::is_same<infra::result_of_t<F, ObserverType&>, void>::value>*) const
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::const_iterator i = observers.begin(); i != observers.end(); )
         {
@@ -254,7 +254,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename infra::enable_if_t<!infra::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
+    bool Subject<ObserverType, void>::NotifyObservers(F callback, infra::enable_if_t<!std::is_same<infra::result_of_t<F, ObserverType&>, void>::value>*)
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::iterator i = observers.begin(); i != observers.end();)
         {

--- a/infra/util/Observer.hpp
+++ b/infra/util/Observer.hpp
@@ -1,6 +1,7 @@
 #ifndef INFRA_OBSERVER_HPP
 #define INFRA_OBSERVER_HPP
 
+#include "infra/util/Compatibility.hpp"
 #include "infra/util/IntrusiveList.hpp"
 #include "infra/util/ReallyAssert.hpp"
 #include <cassert>
@@ -84,13 +85,13 @@ namespace infra
 
     public:
         template<class F>
-            void NotifyObservers(F callback, typename std::enable_if<std::is_same<typename std::result_of<F(ObserverType_&)>::type, void>::value>::type* = 0) const;
+            void NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0) const;
         template<class F>
-            void NotifyObservers(F callback, typename std::enable_if<std::is_same<typename std::result_of<F(ObserverType_&)>::type, void>::value>::type* = 0);
+            void NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0);
         template<class F>
-            bool NotifyObservers(F callback, typename std::enable_if<!std::is_same<typename std::result_of<F(ObserverType_&)>::type, void>::value>::type* = 0) const;
+            bool NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0) const;
         template<class F>
-            bool NotifyObservers(F callback, typename std::enable_if<!std::is_same<typename std::result_of<F(ObserverType_&)>::type, void>::value>::type* = 0);   
+            bool NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType_&>, void>>* = 0);
 
     private:
         IntrusiveList<Observer<ObserverType_, SubjectType>> observers;
@@ -214,7 +215,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    void Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if<std::is_same<typename std::result_of<F(ObserverType&)>::type, void>::value>::type*) const
+    void Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::const_iterator i = observers.begin(); i != observers.end(); )
         {
@@ -226,7 +227,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    void Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if<std::is_same<typename std::result_of<F(ObserverType&)>::type, void>::value>::type*)
+    void Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::iterator i = observers.begin(); i != observers.end();)
         {
@@ -238,7 +239,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if<!std::is_same<typename std::result_of<F(ObserverType&)>::type, void>::value>::type*) const
+    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*) const
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::const_iterator i = observers.begin(); i != observers.end(); )
         {
@@ -253,7 +254,7 @@ namespace infra
 
     template<class ObserverType>
     template<class F>
-    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if<!std::is_same<typename std::result_of<F(ObserverType&)>::type, void>::value>::type*)
+    bool Subject<ObserverType, void>::NotifyObservers(F callback, typename std::enable_if_t<!std::is_same_v<infra::result_of_t<F, ObserverType&>, void>>*)
     {
         for (typename IntrusiveList<Observer<ObserverType, SubjectType>>::iterator i = observers.begin(); i != observers.end();)
         {


### PR DESCRIPTION
std::result_of has been deprecated in C++17 and removed in C++20. Replaced by std::invoke_result.

- Created Compatibility header to support C++11 and higher versions.
- Used Compatibility header in Observer.