### PR TITLE
Fix missing cassert include in IntrusiveBinarySearchTree

### DIFF
--- a/infra/util/IntrusiveBinarySearchTree.hpp
+++ b/infra/util/IntrusiveBinarySearchTree.hpp
@@ -4,6 +4,7 @@
 // Intrusive binary search tree class, used as base for IntrusiveSet
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 #include <iterator>
 #include <tuple>


### PR DESCRIPTION
Fixes #70 