### PR TITLE
Solved TimerRepeating::Start calling NextTriggerChanged twice

### DIFF
--- a/infra/timer/Timer.cpp
+++ b/infra/timer/Timer.cpp
@@ -154,8 +154,8 @@ namespace infra
 
     void TimerRepeating::Start(Duration duration, const infra::Function<void()>& action)
     {
-        SetNextTriggerTime(Now() + Resolution(), action);  // Initialize NextTrigger() for ComputeNextTriggerTime
-        SetDuration(duration);
+        triggerPeriod = duration;
+        SetNextTriggerTime(Now() + TriggerPeriod() + Resolution(), action);
     }
 
     void TimerRepeating::Start(Duration duration, const infra::Function<void()>& action, TriggerImmediately)
@@ -175,12 +175,5 @@ namespace infra
         Duration diff = (now - NextTrigger()) % triggerPeriod;
 
         SetNextTriggerTime(now - diff + triggerPeriod, Action());
-    }
-
-    void TimerRepeating::SetDuration(Duration duration)
-    {
-        triggerPeriod = duration;
-
-        ComputeNextTriggerTime();
     }
 }

--- a/infra/timer/Timer.hpp
+++ b/infra/timer/Timer.hpp
@@ -105,9 +105,6 @@ namespace infra
         virtual void ComputeNextTriggerTime() override;
 
     private:
-        void SetDuration(Duration duration);
-
-    private:
         Duration triggerPeriod = Duration();
     };
 }


### PR DESCRIPTION
TimerRepeating::Start would call NextTriggerChanged twice, once via `SetNextTriggerTime` and once via `SetDuration`.

The call to `SetNextTriggerTime` would result in the underlying timer implementation getting a request to schedule a trigger sooner than the actual duration.

This change solves that issue by removing the double call to `SetNextTriggerChanged` and changing the initial TimePoint value passed to `SetNextTriggerTime` to the correct duration

Fixes #75 