### PR TITLE
infra/util/IntrusiveList: insertion and erase functions now take a non-const reference

### DIFF
--- a/infra/util/IntrusiveForwardList.hpp
+++ b/infra/util/IntrusiveForwardList.hpp
@@ -61,10 +61,10 @@ namespace infra
         const_reference front() const;
 
     public:
-        void push_front(const_reference value);
+        void push_front(reference value);
         void pop_front();
 
-        void insert_after(const_iterator position, const_reference value);
+        void insert_after(const_iterator position, reference value);
         void erase_after(const_reference value);
         void erase_slow(const_reference value); // Runs in O(n) time
 
@@ -259,9 +259,9 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveForwardList<T>::push_front(const_reference value)
+    void IntrusiveForwardList<T>::push_front(reference value)
     {
-        NodeType& node = const_cast<reference>(value);
+        NodeType& node = value;
         node.next = beginNode;
 
         beginNode = &node;
@@ -274,9 +274,9 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveForwardList<T>::insert_after(const_iterator position, const_reference value)
+    void IntrusiveForwardList<T>::insert_after(const_iterator position, reference value)
     {
-        NodeType& node = const_cast<reference>(value);
+        NodeType& node = value;
         node.next = const_cast<NodeType*>(position.mNode)->next;
         const_cast<NodeType*>(position.mNode)->next = &node;
     }

--- a/infra/util/IntrusiveList.hpp
+++ b/infra/util/IntrusiveList.hpp
@@ -95,13 +95,13 @@ namespace infra
         const_reference back() const;
 
     public:
-        void push_front(const_reference value);
-        void push_back(const_reference value);
+        void push_front(reference value);
+        void push_back(reference value);
         void pop_front();
         void pop_back();
 
-        void insert(const_iterator position, const_reference value);
-        void erase(const_reference value);
+        void insert(const_iterator position, reference value);
+        void erase(reference value);
 
         template<class InputIterator>
             void assign(InputIterator first, InputIterator last);
@@ -337,9 +337,9 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveList<T>::push_front(const_reference value)
+    void IntrusiveList<T>::push_front(reference value)
     {
-        NodeType& node = const_cast<reference>(value);
+        NodeType& node = value;
         node.next = beginNode;
         node.previous = nullptr;
 
@@ -351,9 +351,9 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveList<T>::push_back(const_reference value)
+    void IntrusiveList<T>::push_back(reference value)
     {
-        NodeType& node = const_cast<reference>(value);
+        NodeType& node = value;
         node.next = &endNode;
         node.previous = endNode.previous;
 
@@ -388,9 +388,9 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveList<T>::insert(const_iterator position, const_reference value)
+    void IntrusiveList<T>::insert(const_iterator position, reference value)
     {
-        NodeType& node = const_cast<reference>(value);
+        NodeType& node = value;
         node.previous = position.node->previous;
         node.next = const_cast<NodeType*>(position.node);
         const_cast<NodeType*>(position.node)->previous = &node;
@@ -402,9 +402,9 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveList<T>::erase(const_reference value)
+    void IntrusiveList<T>::erase(reference value)
     {
-        NodeType& node = const_cast<reference>(value);
+        NodeType& node = value;
         if (node.previous != nullptr)
             node.previous->next = node.next;
         else if (beginNode != &node)

--- a/infra/util/IntrusiveUnorderedSet.hpp
+++ b/infra/util/IntrusiveUnorderedSet.hpp
@@ -66,12 +66,12 @@ namespace infra
         bool contains(const_reference value) const;
 
     public:
-        void insert(const_reference value);
+        void insert(reference value);
 
         template<class... Args>
             std::pair<iterator, bool> emplace(Args&&... args);
 
-        void erase(const_reference value);
+        void erase(reference value);
 
         template<class InputIterator>
             void assign(InputIterator first, InputIterator last);
@@ -253,7 +253,7 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveUnorderedSet<T>::insert(const_reference value)
+    void IntrusiveUnorderedSet<T>::insert(reference value)
     {
         auto& bucket = buckets[HashToBucket(value)];
 
@@ -262,7 +262,7 @@ namespace infra
     }
 
     template<class T>
-    void IntrusiveUnorderedSet<T>::erase(const_reference value)
+    void IntrusiveUnorderedSet<T>::erase(reference value)
     {
         auto& bucket = buckets[HashToBucket(value)];
 

--- a/services/ble/Gatt.cpp
+++ b/services/ble/Gatt.cpp
@@ -21,7 +21,7 @@ namespace services
         : attribute{type, 0}
     {}
 
-    void GattService::AddCharacteristic(const GattCharacteristic& characteristic)
+    void GattService::AddCharacteristic(GattCharacteristic& characteristic)
     {
         characteristics.push_front(characteristic);
     }

--- a/services/ble/Gatt.hpp
+++ b/services/ble/Gatt.hpp
@@ -134,7 +134,7 @@ namespace services
         GattService& operator=(const GattService& other) = delete;
         virtual ~GattService() = default;
 
-        void AddCharacteristic(const GattCharacteristic& characteristic);
+        void AddCharacteristic(GattCharacteristic& characteristic);
         infra::IntrusiveForwardList<GattCharacteristic>& Characteristics();
         const infra::IntrusiveForwardList<GattCharacteristic>& Characteristics() const;
 

--- a/services/cucumber/CucumberStepStorage.cpp
+++ b/services/cucumber/CucumberStepStorage.cpp
@@ -144,12 +144,12 @@ namespace services
         return *std::next(stepList.begin(), id);
     }
 
-    void CucumberStepStorage::AddStep(const CucumberStep& step)
+    void CucumberStepStorage::AddStep(CucumberStep& step)
     {
         stepList.push_back(step);
     }
 
-    void CucumberStepStorage::DeleteStep(const CucumberStep& step)
+    void CucumberStepStorage::DeleteStep(CucumberStep& step)
     {
         stepList.erase(step);
     }

--- a/services/cucumber/CucumberStepStorage.hpp
+++ b/services/cucumber/CucumberStepStorage.hpp
@@ -34,8 +34,8 @@ namespace services
         services::CucumberStepStorage::Match MatchStep(const infra::BoundedString& nameToMatch);
 
         CucumberStep& GetStep(uint32_t id);
-        void AddStep(const CucumberStep& step);
-        void DeleteStep(const CucumberStep& step);
+        void AddStep(CucumberStep& step);
+        void DeleteStep(CucumberStep& step);
         void ClearStorage();
 
     private:


### PR DESCRIPTION
infra/util/IntrusiveList, IntrusiveForwardList, IntrusiveUnorderedSet: insertion and erase functions now take a non-const reference, avoiding temporaries to be inserted