### PR TITLE
cmake/emil_docker_tools.cmake: add support for host Docker tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gnupg2=2.2.19-3ubuntu2.2 \
         iwyu=8.0-3build1 \
         libllvm12=1:12.0.0-3ubuntu1~20.04.5 \
-        libxml2=2.9.10+dfsg-5ubuntu0.20.04.3 \
+        libxml2=2.9.10+dfsg-5ubuntu0.20.04.4 \
         lsb-release=11.1.0ubuntu2 \
         ninja-build=1.10.0-1build1 \
         python3=3.8.2-0ubuntu2 \

--- a/cmake/emil_docker_tools.cmake
+++ b/cmake/emil_docker_tools.cmake
@@ -1,10 +1,27 @@
+# This module will include Docker tools as custom targets in a build-tree.
+#
+# Three scenario's are supported:
+# - Running inside a devcontainer using a volume-mount (e.g. clone in container volume)
+# - Running inside a devcontainer using a bind-mount (e.g. (re-)open in container)
+# - Running native with Docker installed on the host
+#
+# The first two scenarios require a Docker cli to be installed inside the container,
+# the Docker socket exposed inside that container and the workspace location exported
+# as environment variable (LOCAL_WORKSPACE_FOLDER).
+# See: https://github.com/microsoft/vscode-dev-containers/tree/main/containers/docker-from-docker
+#
+# The third scenario directly interacts with the Docker instance on the host machine.
+
 find_program(DOCKER docker)
 
 if (DOCKER)
+    cmake_host_system_information(RESULT hostname QUERY HOSTNAME)
+
     execute_process(
-        COMMAND ${DOCKER} inspect -f "{{ range .Mounts }}{{ if eq .Destination \"/workspaces\" }}{{ .Name }}{{ end }}{{ end }}" $ENV{HOSTNAME}
+        COMMAND ${DOCKER} inspect -f "{{ range .Mounts }}{{ if eq .Destination \"/workspaces\" }}{{ .Name }}{{ end }}{{ end }}" ${hostname}
         OUTPUT_VARIABLE docker_volume
         OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
     )
 
     if (NOT docker_volume STREQUAL "")
@@ -18,7 +35,9 @@ if (DOCKER)
         cmake_path(GET docker_mountpoint PARENT_PATH docker_mountpoint_parent)
         cmake_path(GET docker_mountpoint STEM docker_mountpoint_stem)
     else()
-        message(WARNING "Could not determine paths and mount-points for Docker tools")
+        string(REPLACE "\\" "/" docker_mountpoint ${CMAKE_SOURCE_DIR})
+        cmake_path(GET docker_mountpoint PARENT_PATH docker_mountpoint_parent)
+        cmake_path(GET docker_mountpoint STEM docker_mountpoint_stem)
     endif()
 
     add_custom_target(lint


### PR DESCRIPTION
When running outside of a devcontainer, but Docker is installed add the option to run additional tools directly on the host.